### PR TITLE
Add Api endpoint for payments between two users

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,62 +1,68 @@
-openapi: "3.0.1"
+openapi: 3.0.1
 info:
-  description: This is an opensplit server. You can find out more about Opensplit at [http://openspl.it](http://openspl.it).
-  version: "1.0.0"
+  description: >-
+    This is an opensplit server. You can find out more about Opensplit at
+    [http://openspl.it](http://openspl.it).
+  version: 1.0.0
   title: Opensplit
-  termsOfService: ""
+  termsOfService: ''
   contact:
     email: thegrumps@darmstadt.ccc.de
   license:
     name: AGPL 3.0
-    url: https://www.gnu.org/licenses/agpl-3.0.html
+    url: 'https://www.gnu.org/licenses/agpl-3.0.html'
 servers:
-- url: http://app.openspl.it
-  description: production server
+  - url: 'http://app.openspl.it'
+    description: production server
 tags:
-- name: users
-  description: Operations related to users
-- name: messages
-  description: Operations related to messages
-- name: groups
-  description: Operations related to groups
-- name: transactions
-  description: Operations related to transactions of a group
+  - name: users
+    description: Operations related to users
+  - name: messages
+    description: Operations related to messages
+  - name: groups
+    description: Operations related to groups
+  - name: transactions
+    description: Operations related to transactions of a group
+  - name: payments
+    description: Operations related to payments between two users in a group
 paths:
   /users:
     get:
       tags:
-      - users
+        - users
       description: Returns a list of all users
       responses:
-        200:
+        '200':
           description: User list retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/UserInfo"
-        401:
+                  $ref: '#/components/schemas/UserInfo'
+        '401':
           description: Session expired
     post:
       tags:
-      - users
-      description: Creates a user account and emails an activation token to the specified email address
+        - users
+      description: >-
+        Creates a user account and emails an activation token to the specified
+        email address
       requestBody:
         required: true
         description: Username and email for the new user account
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserInfo"
+              $ref: '#/components/schemas/UserInfo'
       responses:
-        201:
+        '201':
           description: User account successfully created and email sent
-        400:
+        '400':
           description: Malformed or invalid body content
     put:
       tags:
-      - users
+        - users
       description: Update own user data
       requestBody:
         required: true
@@ -64,67 +70,69 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserInfo"
+              $ref: '#/components/schemas/UserInfo'
       responses:
-        200:
+        '200':
           description: User account successfully updated
           content:
             application/json:
               schema:
                 description: A description of the result of the action
                 type: string
-                example: "Updated user data: current username is AwesomeUser and current email is awesome_user@example.com"
-        400:
+                example: >-
+                  Updated user data: current username is AwesomeUser and current
+                  email is awesome_user@example.com
+        '400':
           description: Malformed body content
-        401:
+        '401':
           description: Session expired
     delete:
       tags:
-      - users
+        - users
       description: Deletes own user account
       responses:
-        200:
+        '200':
           description: User deleted successfully
-        401:
+        '401':
           description: Session expired
-  /users/{userId}:
+  '/users/{userId}':
     get:
       tags:
-      - users
+        - users
       description: Returns the user's ID and email
       parameters:
-      - name: userId
-        in: path
-        description: ID of the user to be returned
-        required: true
-        schema:
-          type: string
+        - name: userId
+          in: path
+          description: ID of the user to be returned
+          required: true
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: User info retrieved successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserInfo"
-        401:
+                $ref: '#/components/schemas/UserInfo'
+        '401':
           description: Session expired
-        404:
+        '404':
           description: Invalid userID in the path parameter
   /messages:
     get:
       tags:
-      - messages
+        - messages
       description: Returns a list of all messages for the current user
       responses:
-        200:
+        '200':
           description: Message list retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Message"
-        401:
+                  $ref: '#/components/schemas/Message'
+        '401':
           description: Session expired
     post:
       tags:
@@ -138,160 +146,160 @@ paths:
             schema:
               type: object
               required:
-              - recipient
-              - text
+                - recipient
+                - text
               properties:
                 recipient:
                   type: string
                   example: AmazingUser
                 text:
                   type: string
-                  example: Hello AmazingUser, how do you do?
+                  example: 'Hello AmazingUser, how do you do?'
       responses:
-        201:
+        '201':
           description: Message successfully created
-        400:
+        '400':
           description: Malformed or invalid body content
-        401:
+        '401':
           description: Session expired
-  /messages/{messageId}:
+  '/messages/{messageId}':
     get:
       tags:
-      - messages
+        - messages
       description: Returns a given message belonging to the current user
       parameters:
-      - name: messageId
-        in: path
-        required: true
-        description: ID of the message to be returned
-        schema:
-          type: string
+        - name: messageId
+          in: path
+          required: true
+          description: ID of the message to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Message retrieved successfully
           content:
             application/json:
               schema:
-               $ref: "#/components/schemas/Message"
-        401:
+                $ref: '#/components/schemas/Message'
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this message
-        404:
+        '404':
           description: Invalid messageId in the path parameter
   /groups:
     get:
       tags:
-      - groups
+        - groups
       description: Returns a list of all groups for the current user
       responses:
-        200:
+        '200':
           description: Group list retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Group"
-        403:
+                  $ref: '#/components/schemas/Group'
+        '403':
           description: Session expired
-  /groups/{groupId}:
+  '/groups/{groupId}':
     get:
       tags:
-      - groups
+        - groups
       description: Returns the group with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Group retrieved successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Group"
-        401:
+                $ref: '#/components/schemas/Group'
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId in the path parameter
-  /groups/{groupId}/users:
+  '/groups/{groupId}/users':
     get:
       tags:
-      - groups
+        - groups
       description: Returns a list of all users in the group
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group whose users are to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group whose users are to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: User list retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/UserInfo"
-        401:
+                  $ref: '#/components/schemas/UserInfo'
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId in the path parameter
-  /groups/{groupId}/generateToken:
+  '/groups/{groupId}/generateToken':
     get:
       tags:
-      - groups
+        - groups
       description: Returns a token to authorize joiningthe group with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Token retrieved successfully
           content:
             application/json:
               schema:
                 type: string
-        401:
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId in the path parameter
-  /groups/{groupId}/join/{token}:
+  '/groups/{groupId}/join/{token}':
     post:
       tags:
-      - groups
+        - groups
       description: Makes the current user join the group with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group to be returned
-        schema:
-          type: string
-      - in: path
-        name: token
-        required: true
-        description: Token to authorize the membership change
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group to be returned
+          schema:
+            type: string
+        - in: path
+          name: token
+          required: true
+          description: Token to authorize the membership change
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Group joined successfully
           content:
             application/json:
@@ -299,26 +307,26 @@ paths:
                 description: Information on the joining operation
                 type: string
                 example: User has successfully joined group 'Epic Group'
-        401:
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId or token in the path parameter
-  /groups/{groupId}/leave:
+  '/groups/{groupId}/leave':
     post:
       tags:
-      - groups
+        - groups
       description: Makes the current user leave the group with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Group left successfully
           content:
             application/json:
@@ -326,166 +334,222 @@ paths:
                 description: Information on the leaving operation
                 type: string
                 example: User has successfully left group 'Boring Group'
-        401:
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId in the path parameter
-  /groups/{groupId}/transactions:
+  '/groups/{groupId}/transactions':
     get:
       tags:
-      - transactions
+        - transactions
       description: Returns a list of all transactions of the group
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group whose transactions are to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group whose transactions are to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Transaction list retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Transaction"
-        401:
+                  $ref: '#/components/schemas/Transaction'
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId in the path parameter
     post:
       tags:
-      - transactions
+        - transactions
       description: Creates a transaction in this group.
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group whose transactions are to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group whose transactions are to be returned
+          schema:
+            type: string
       requestBody:
         description: New transaction object
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Transaction"
+              $ref: '#/components/schemas/Transaction'
       responses:
-        201:
+        '201':
           description: Transaction successfully created
-        400:
+        '400':
           description: Malformed or invalid body content
-        401:
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId in the path parameter
-  /groups/{groupId}/transactions/{transactionId}:
+  '/groups/{groupId}/transactions/{transactionId}':
     get:
       tags:
-      - transactions
+        - transactions
       description: Returns the transaction with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group with this transaction
-        schema:
-          type: string
-      - in: path
-        name: transactionId
-        required: true
-        description: ID of the transaction to be returned
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group with this transaction
+          schema:
+            type: string
+        - in: path
+          name: transactionId
+          required: true
+          description: ID of the transaction to be returned
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Transaction retrieved successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Transaction"
-        401:
+                $ref: '#/components/schemas/Transaction'
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId or transactionId in the path parameter
     put:
       tags:
-      - transactions
+        - transactions
       description: Update the transaction with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group with this transaction
-        schema:
-          type: string
-      - in: path
-        name: transactionId
-        required: true
-        description: ID of the transaction to be updated
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group with this transaction
+          schema:
+            type: string
+        - in: path
+          name: transactionId
+          required: true
+          description: ID of the transaction to be updated
+          schema:
+            type: string
       requestBody:
         required: true
         description: Transaction object to replace the current one
         content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Transaction"
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transaction'
       responses:
-        200:
+        '200':
           description: Transaction updated successfully
           content:
             application/json:
               schema:
                 description: A description of the result of the action
                 type: string
-                example: Transaction of 30€ between Albert, Berta and Christine successfully updated.
-        400:
+                example: >-
+                  Transaction of 30€ between Albert, Berta and Christine
+                  successfully updated.
+        '400':
           description: Malformed or invalid body content
-        401:
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId or transactionId in the path parameter
     delete:
       tags:
-      - transactions
+        - transactions
       description: Deletes the transaction with matching ID
       parameters:
-      - in: path
-        name: groupId
-        required: true
-        description: ID of the group with this transaction
-        schema:
-          type: string
-      - in: path
-        name: transactionId
-        required: true
-        description: ID of the transaction to be deleted
-        schema:
-          type: string
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group with this transaction
+          schema:
+            type: string
+        - in: path
+          name: transactionId
+          required: true
+          description: ID of the transaction to be deleted
+          schema:
+            type: string
       responses:
-        200:
+        '200':
           description: Transaction deleted successfully
-        401:
+        '401':
           description: Session expired
-        403:
+        '403':
           description: User does not have permission to access this group
-        404:
+        '404':
           description: Invalid groupId or transactionId in the path parameter
+  '/groups/{groupId}/paments':
+    get:
+      tags:
+        - payments
+      description: Returns a list of all payments of a group between two users
+      parameters:
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group with this transaction
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Payments retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '401':
+          description: Session expired
+        '403':
+          description: User does not have permission to access this group
+        '404':
+          description: Invalid groupId
+    post:
+      tags:
+        - payments
+      description: Creates a payment in this group.
+      parameters:
+        - in: path
+          name: groupId
+          required: true
+          description: ID of the group whose transactions are to be returned
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Receiver, sender and amount if the payment
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentPost'
+      responses:
+        '201':
+          description: Payment successfully created
+        '400':
+          description: Malformed or invalid body content
+        '401':
+          description: Session expired
+        '403':
+          description: User does not have permission to access this group
+        '404':
+          description: Invalid groupId in the path parameter
 components:
   schemas:
     UserInfo:
@@ -503,9 +567,9 @@ components:
     Message:
       type: object
       required:
-      - sender
-      - recipient
-      - content
+        - sender
+        - recipient
+        - content
       properties:
         sender:
           description: The sender of the message
@@ -519,14 +583,14 @@ components:
     Transaction:
       type: object
       required:
-      - payer
-      - value
-      - members
+        - payer
+        - value
+        - members
       properties:
         payer:
-          description: The ID of the ser who paid the transaction
+          description: The ID of the user who paid the transaction
           type: string
-          example: "4d37a80d"
+          example: 4d37a80d
         value:
           description: The total value of the transaction
           type: number
@@ -536,13 +600,52 @@ components:
           type: array
           items:
             type: string
-            example: "1ab34d9c"
+            example: 1ab34d9c
+    Payment:
+      type: object
+      required:
+        - paid_by
+        - amount
+        - split_amongst
+      properties:
+        paid_by:
+          description: The ID of the user who transfered the payment
+          type: string
+          example: 42
+        amount:
+          description: The total value of the transaction
+          type: number
+          example: 13.37
+        split_amongst:
+          description: The user who received the payment is alone in split_amongst as
+                       he receives the full payment.
+          type: object
+          example: {id: 1,
+                    name: user1,
+                    email: user1@user1mail.org
+          }
+    PaymentPost:
+      type: object
+      required:
+        - amount
+        - paid_by
+        - receiver
+      properties:
+        amount:
+          type: string
+          example: 23.42
+        sender:
+          type: string
+          example: user1
+        receiver:
+          type: string
+          example: user2
     Group:
       type: object
       required:
-      - name
-      - balance
-      - owner
+        - name
+        - balance
+        - owner
       properties:
         name:
           description: The name of the group
@@ -555,4 +658,4 @@ components:
         owner:
           description: The ID of the user who owns the group
           type: string
-          example: "4d37a80d"
+          example: 4d37a80d

--- a/opensplit/models.py
+++ b/opensplit/models.py
@@ -116,4 +116,5 @@ class Expense(db.Model):
                 "amount": float(self.amount),
                 "group_id": self.group_id,
                 "paid_by": self.paid_by,
+                "is_payment": self.is_payment,
                 "split_amongst": [u.jsonify() for u in self.split_amongst]}

--- a/opensplit/models.py
+++ b/opensplit/models.py
@@ -70,7 +70,6 @@ class Group(db.Model):
     token = Column(String(40), nullable=False)
     owner = Column(Integer, ForeignKey('user.id'), nullable=False)
     expenses = relationship('Expense', backref='group', lazy=True)
-    payment = relationship('Payment', backref='group', lazy=True)
     member = relationship(
         "User",
         secondary=group_assoc,

--- a/opensplit/views.py
+++ b/opensplit/views.py
@@ -208,7 +208,7 @@ class TransactionResource(Resource):
 payment_post_parser = reqparse.RequestParser()
 payment_post_parser.add_argument('amount', required=True)
 payment_post_parser.add_argument('paid_by', required=True)
-payment_post_parser.add_argument('split_amongst', action='append', required=True)
+payment_post_parser.add_argument('receiver', required=True)
 
 
 class PaymentResource(Resource):
@@ -225,8 +225,8 @@ class PaymentResource(Resource):
                            group_id=group_id,
                            paid_by=args["paid_by"],
                            is_payment=True)
-        for user_id in args["split_amongst"]:
-            e.split_amongst.append(models.User.query.get(user_id))
+        e.split_amongst.append(models.User.query.get(args["receiver"]))
+        e.split_amongst.append(models.User.query.get(args["paid_by"]))
         db.session.add(e)
         db.session.commit()
         return {"message": "success"}

--- a/opensplit/views.py
+++ b/opensplit/views.py
@@ -226,7 +226,6 @@ class PaymentResource(Resource):
                            paid_by=args["paid_by"],
                            is_payment=True)
         e.split_amongst.append(models.User.query.get(args["receiver"]))
-        e.split_amongst.append(models.User.query.get(args["paid_by"]))
         db.session.add(e)
         db.session.commit()
         return {"message": "success"}

--- a/opensplit/views.py
+++ b/opensplit/views.py
@@ -191,7 +191,7 @@ class TransactionResource(Resource):
 
     def get(self, group_id):
         group = models.Group.query.get(group_id)
-        return [expense.jsonify() for expense in group.expenses],
+        return [expense.jsonify() for expense in group.expenses if not expense.is_payment],
 
     def post(self, group_id):
         args = expense_post_parser.parse_args()

--- a/opensplit/views.py
+++ b/opensplit/views.py
@@ -204,6 +204,13 @@ class TransactionResource(Resource):
         db.session.add(e)
         db.session.commit()
 
+class PaymentResource(Resource):
+    method_decorators = [authenticate]
+
+    def get(self, group_id):
+        group = models.Group.query.get(group_id)
+        return [expense.jsonify() for expense in group.expenses if expense.is_payment]
+
 
 class CheckResource(Resource):
     method_decorators = [authenticate]
@@ -226,5 +233,7 @@ api.add_resource(SessionResource, '/session/<string:login_token>')
 api.add_resource(LoginResource, '/login/<string:email>')
 
 api.add_resource(TransactionResource, '/groups/<int:group_id>/transactions')
+
+api.add_resource(PaymentResource, '/groups/<int:group_id>/payments')
 
 api.add_resource(CheckResource, '/checktoken')

--- a/opensplit/views.py
+++ b/opensplit/views.py
@@ -207,7 +207,7 @@ class TransactionResource(Resource):
 
 payment_post_parser = reqparse.RequestParser()
 payment_post_parser.add_argument('amount', required=True)
-payment_post_parser.add_argument('paid_by', required=True)
+payment_post_parser.add_argument('sender', required=True)
 payment_post_parser.add_argument('receiver', required=True)
 
 
@@ -220,12 +220,15 @@ class PaymentResource(Resource):
 
     def post(self, group_id):
         args = payment_post_parser.parse_args()
+        receiver_id = models.User.query.filter_by(name=args["receiver"]).first()
+        sender_id = models.User.query.filter_by(name=args["sender"]).first().id
+
         e = models.Expense(description="Payment",
                            amount=args["amount"],
                            group_id=group_id,
-                           paid_by=args["paid_by"],
+                           paid_by=sender_id,
                            is_payment=True)
-        e.split_amongst.append(models.User.query.get(args["receiver"]))
+        e.split_amongst.append(receiver_id)
         db.session.add(e)
         db.session.commit()
         return {"message": "success"}


### PR DESCRIPTION
This merge will add an endpoint /groups/<group_id>/payments to add and receive payments which settle debts between two users. As the sender will be added alone into the existing "split_amongst" of an expense, we can use the existing calculation without adjustments.

As we will refactor this part anyway into some tree modelish to implement simplifying we probably won't have to adjust this anymore right now.

The documentation has also been updated. The section payment has been added and contains the current state of this endpoint. The other endpoints probably still need some adjustment.